### PR TITLE
[9.16.r1] msm: ipa3: Fix -Wenum-conversion

### DIFF
--- a/drivers/platform/msm/ipa/ipa_v3/rmnet_ipa.c
+++ b/drivers/platform/msm/ipa/ipa_v3/rmnet_ipa.c
@@ -507,8 +507,8 @@ static void ipa3_copy_qmi_flt_rule_ex(
 	 */
 	flt_spec_ptr = (struct ipa_filter_spec_ex_type_v01 *) flt_spec_ptr_void;
 
-	q6_ul_flt_rule_ptr->ip = flt_spec_ptr->ip_type;
-	q6_ul_flt_rule_ptr->action = flt_spec_ptr->filter_action;
+	q6_ul_flt_rule_ptr->ip = (enum ipa_ip_type)flt_spec_ptr->ip_type;
+	q6_ul_flt_rule_ptr->action = (enum ipa_flt_action)flt_spec_ptr->filter_action;
 	if (flt_spec_ptr->is_routing_table_index_valid == true)
 		q6_ul_flt_rule_ptr->rt_tbl_idx =
 		flt_spec_ptr->route_table_index;


### PR DESCRIPTION
```
techpack/dataipa/drivers/platform/msm/ipa/ipa_v3/rmnet_ipa.c:510:41:
error: implicit conversion from enumeration type 'enum ipa_ip_type_enum_v01'
to different enumeration type 'enum ipa_ip_type' [-Werror,-Wenum-conversion]
        q6_ul_flt_rule_ptr->ip = flt_spec_ptr->ip_type;
                               ~ ~~~~~~~~~~~~~~^~~~~~~

techpack/dataipa/drivers/platform/msm/ipa/ipa_v3/rmnet_ipa.c:511:45:
error: implicit conversion from enumeration type 'enum ipa_filter_action_enum_v01'
to different enumeration type 'enum ipa_flt_action' [-Werror,-Wenum-conversion]
        q6_ul_flt_rule_ptr->action = flt_spec_ptr->filter_action;
                                   ~ ~~~~~~~~~~~~~~^~~~~~~~~~~~~

2 errors generated.
```