### PR TITLE
[9.16.r1] Revert "msm: ipa: load IPA FW after smmu CB are probed"

### DIFF
--- a/drivers/platform/msm/ipa/ipa_v3/ipa_i.h
+++ b/drivers/platform/msm/ipa/ipa_v3/ipa_i.h
@@ -1824,24 +1824,6 @@ struct ipa3_pc_mbox_data {
 	struct mbox_chan *mbox;
 };
 
-enum ipa_fw_load_state {
-	IPA_FW_LOAD_STATE_INIT,
-	IPA_FW_LOAD_STATE_FWFILE_READY,
-	IPA_FW_LOAD_STATE_SMMU_DONE,
-	IPA_FW_LOAD_STATE_LOAD_READY,
-	IPA_FW_LOAD_STATE_LOADED,
-};
-
-enum ipa_fw_load_event {
-	IPA_FW_LOAD_EVNT_FWFILE_READY,
-	IPA_FW_LOAD_EVNT_SMMU_DONE,
-};
-
-struct ipa_fw_load_data {
-	enum ipa_fw_load_state state;
-	struct mutex lock;
-};
-
 struct ipa3_app_clock_vote {
 	struct mutex mutex;
 	u32 cnt;
@@ -2123,7 +2105,7 @@ struct ipa3_context {
 
 	int (*client_lock_unlock[IPA_MAX_CLNT])(bool is_lock);
 
-	struct ipa_fw_load_data fw_load_data;
+	bool fw_loaded;
 
 	bool (*get_teth_port_state[IPA_MAX_CLNT])(void);
 


### PR DESCRIPTION
This reverts commit https://github.com/sonyxperiadev/kernel/commit/d3e8fba

Do not attempt to load the firmware immediately after
probing the SMMU. We are building the IPA driver as
built-in, which means it will try to load the firmware
immediately, even in recovery. To prevent this and ensure
the firmware is only loaded via a userspace trigger, as
it was before, revert this change.